### PR TITLE
Bump version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To use this plugin you must add it to your build script. This can be done using 
 **Plugin DSL**    
 ```gradle
 plugins {
-    id "com.modrinth.minotaur" version "1.1.0"
+    id "com.modrinth.minotaur" version "1.2.1"
 }
 ```
 
@@ -20,7 +20,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath group: 'gradle.plugin.com.modrinth.minotaur', name: 'Minotaur', version: '1.1.0'
+        classpath group: 'gradle.plugin.com.modrinth.minotaur', name: 'Minotaur', version: '1.2.1'
     }
 }
 ```
@@ -112,7 +112,6 @@ In some cases you may want to use the JAR file directly in your script rather th
 ```groovy
 buildscript {
     repositories {
-        jcenter()
         mavenCentral()
     }
     dependencies {

--- a/src/test/resources/localtest/build.gradle
+++ b/src/test/resources/localtest/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath group: 'com.modrinth.minotaur', name: 'Minotaur', version: '1.0.0'
+        classpath group: 'com.modrinth.minotaur', name: 'Minotaur', version: '1.2.1'
     }
 }
 


### PR DESCRIPTION
This also bumps the version in the test env (I don't even think that's used at all but might as well for good measure)
I also removed jcenter from the sample blurb in the readme.

(yes I committed it to master, it doesn't really matter since this is probably going to be my only ever contribution to minotaur)