### PR TITLE
Allow accessing uploadFile as a RegularFileProperty

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'com.gradle.plugin-publish' version '1.1.0'
 }
 
-version = '2.7.1'
+version = '2.7.2'
 group = 'com.modrinth.minotaur'
 archivesBaseName = 'Minotaur'
 description = 'Modrinth plugin for publishing builds to the website!'

--- a/src/main/java/com/modrinth/minotaur/Minotaur.java
+++ b/src/main/java/com/modrinth/minotaur/Minotaur.java
@@ -75,7 +75,7 @@ public class Minotaur implements Plugin<Project> {
 			}
 
 			evaluatedProject.getTasks().named("modrinth", TaskModrinthUpload.class).configure(task -> {
-				task.getWiredInputFiles().from(ext.getUploadFileProperty());
+				task.getWiredInputFiles().from(ext.getFile());
 
 				ext.getAdditionalFiles().get().forEach(file -> {
 					if (file == null) {

--- a/src/main/java/com/modrinth/minotaur/ModrinthExtension.java
+++ b/src/main/java/com/modrinth/minotaur/ModrinthExtension.java
@@ -15,7 +15,7 @@ import org.gradle.api.provider.Property;
 public class ModrinthExtension extends DependencyDSL {
 	private final Property<String> apiUrl, token, projectId, versionNumber, versionName, changelog, versionType, syncBodyFrom;
 	private final Property<Object> legacyUploadFile;
-	private final RegularFileProperty uploadFile;
+	private final RegularFileProperty file;
 	private final ListProperty<Object> additionalFiles;
 	private final ListProperty<String> gameVersions, loaders;
 	private final ListProperty<Dependency> dependencies;
@@ -54,7 +54,7 @@ public class ModrinthExtension extends DependencyDSL {
 		versionName = project.getObjects().property(String.class);
 		changelog = project.getObjects().property(String.class).convention(DEFAULT_CHANGELOG);
 		legacyUploadFile = project.getObjects().property(Object.class);
-		uploadFile = project.getObjects().fileProperty().convention(legacyUploadFile.flatMap(o -> Util.resolveFileProperty(project, o)));
+		file = project.getObjects().fileProperty().convention(legacyUploadFile.flatMap(o -> Util.resolveFileProperty(project, o)));
 		additionalFiles = project.getObjects().listProperty(Object.class).empty();
 		versionType = project.getObjects().property(String.class).convention(DEFAULT_VERSION_TYPE);
 		gameVersions = project.getObjects().listProperty(String.class).empty();
@@ -127,8 +127,8 @@ public class ModrinthExtension extends DependencyDSL {
 	 *
 	 * @return file property
 	 */
-	public RegularFileProperty getUploadFileProperty() {
-		return this.uploadFile;
+	public RegularFileProperty getFile() {
+		return this.file;
 	}
 
 	/**

--- a/src/main/java/com/modrinth/minotaur/ModrinthExtension.java
+++ b/src/main/java/com/modrinth/minotaur/ModrinthExtension.java
@@ -4,6 +4,7 @@ import com.modrinth.minotaur.dependencies.Dependency;
 import com.modrinth.minotaur.dependencies.container.DependencyDSL;
 import masecla.modrinth4j.model.version.ProjectVersion.VersionType;
 import org.gradle.api.Project;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
@@ -13,7 +14,8 @@ import org.gradle.api.provider.Property;
  */
 public class ModrinthExtension extends DependencyDSL {
 	private final Property<String> apiUrl, token, projectId, versionNumber, versionName, changelog, versionType, syncBodyFrom;
-	private final Property<Object> uploadFile;
+	private final Property<Object> legacyUploadFile;
+	private final RegularFileProperty uploadFile;
 	private final ListProperty<Object> additionalFiles;
 	private final ListProperty<String> gameVersions, loaders;
 	private final ListProperty<Dependency> dependencies;
@@ -51,7 +53,8 @@ public class ModrinthExtension extends DependencyDSL {
 		versionNumber = project.getObjects().property(String.class);
 		versionName = project.getObjects().property(String.class);
 		changelog = project.getObjects().property(String.class).convention(DEFAULT_CHANGELOG);
-		uploadFile = project.getObjects().property(Object.class);
+		legacyUploadFile = project.getObjects().property(Object.class);
+		uploadFile = project.getObjects().fileProperty().convention(legacyUploadFile.flatMap(o -> Util.resolveFileProperty(project, o)));
 		additionalFiles = project.getObjects().listProperty(Object.class).empty();
 		versionType = project.getObjects().property(String.class).convention(DEFAULT_VERSION_TYPE);
 		gameVersions = project.getObjects().listProperty(String.class).empty();
@@ -116,6 +119,15 @@ public class ModrinthExtension extends DependencyDSL {
 	 * {@link Util#resolveFile(Project, Object)}.
 	 */
 	public Property<Object> getUploadFile() {
+		return this.legacyUploadFile;
+	}
+
+	/**
+	 * The upload artifact file.
+	 *
+	 * @return file property
+	 */
+	public RegularFileProperty getUploadFileProperty() {
 		return this.uploadFile;
 	}
 

--- a/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java
+++ b/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java
@@ -11,7 +11,10 @@ import masecla.modrinth4j.model.version.ProjectVersion.ProjectDependency;
 import masecla.modrinth4j.model.version.ProjectVersion.VersionType;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.plugins.PluginManager;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.jetbrains.annotations.ApiStatus;
 
@@ -24,7 +27,7 @@ import static com.modrinth.minotaur.Util.*;
 /**
  * A task used to communicate with Modrinth for the purpose of uploading build artifacts.
  */
-public class TaskModrinthUpload extends DefaultTask {
+public abstract class TaskModrinthUpload extends DefaultTask {
 	/**
 	 * The response from the API when the file was uploaded successfully.
 	 */
@@ -54,6 +57,16 @@ public class TaskModrinthUpload extends DefaultTask {
 	public boolean wasUploadSuccessful() {
 		return newVersion != null;
 	}
+
+	/**
+	 * Input property used to add automatic task dependencies.
+	 *
+	 * @return property
+	 */
+	@InputFiles
+	@Optional
+	@ApiStatus.Internal
+	public abstract ConfigurableFileCollection getWiredInputFiles();
 
 	/**
 	 * Defines what to do when the Modrinth upload task is invoked.
@@ -145,7 +158,7 @@ public class TaskModrinthUpload extends DefaultTask {
 
 			// Get each of the files, starting with the primary file
 			List<File> files = new ArrayList<>();
-			files.add(resolveFile(getProject(), ext.getUploadFile().get()));
+			files.add(ext.getUploadFileProperty().get().getAsFile());
 
 			// Convert each of the Object files from the extension to a proper File
 			ext.getAdditionalFiles().get().forEach(file -> {

--- a/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java
+++ b/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java
@@ -158,7 +158,7 @@ public abstract class TaskModrinthUpload extends DefaultTask {
 
 			// Get each of the files, starting with the primary file
 			List<File> files = new ArrayList<>();
-			files.add(ext.getUploadFileProperty().get().getAsFile());
+			files.add(ext.getFile().get().getAsFile());
 
 			// Convert each of the Object files from the extension to a proper File
 			ext.getAdditionalFiles().get().forEach(file -> {


### PR DESCRIPTION
I found it quite confusing when I was unable to do either
```kotlin
uploadFile.set(tasks.shadowJar.flatMap { it.archiveFile })
// or
uploadFile.set(tasks.shadowJar)
```
due to overload resolution ambiguity.
In order to get it working I had to employ one of the following:
```kotlin
uploadFile.set(tasks.shadowJar.get())
// or
(uploadFile as Property<Task>).set(tasks.shadowJar)
```

With this change the old `Property<Object>` will continue to work as before, but a new method for accessing the property as a `RegularFileProperty` is now available, so `uploadFileProperty.set(tasks.shadowJar.flatMap { it.archiveFile })` will work as expected (with groovy this would be `uploadFileProperty.set(tasks.shadowJar.archiveFile)`). Additionally, it allows for auto task dependency wiring when using a non-`AbstractArchiveTask` task type.

If this change is accepted I think a similar change would be good to apply for the additional files.