### PR TITLE
Support NeoForge's ModDevGradle

### DIFF
--- a/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java
+++ b/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java
@@ -108,6 +108,8 @@ public abstract class TaskModrinthUpload extends DefaultTask {
 				pluginLoaderMap.put("net.minecraftforge.gradle", "forge");
 				pluginLoaderMap.put("net.neoforged.gradle", "neoforge");
 				pluginLoaderMap.put("net.neoforged.gradle.userdev", "neoforge");
+				pluginLoaderMap.put("net.neoforged.moddev", "neoforge");
+				pluginLoaderMap.put("net.neoforged.moddev.legacyforge", "forge");
 				pluginLoaderMap.put("org.quiltmc.loom", "quilt");
 				pluginLoaderMap.put("org.spongepowered.gradle.plugin", "sponge");
 				pluginLoaderMap.put("io.papermc.paperweight.userdev", "paper");


### PR DESCRIPTION
Fixes #67.

This doesn't add support for version detection within those plugins. I wonder if it's worth moving [the code that sniffs properties](https://github.com/modrinth/minotaur/blob/a151c425fb128cd5384242f25b6fbb0a1d18e325/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java#L148-L161) after the Loom/Paperweight version detection and, and always using that if a version cannot be found, rather than just doing that for NG/FG.