### PR TITLE
fix: honor autoAddDependsOn=false for assemble/build wiring (#81)

### DIFF
--- a/src/main/java/com/modrinth/minotaur/Minotaur.java
+++ b/src/main/java/com/modrinth/minotaur/Minotaur.java
@@ -27,8 +27,6 @@ public class Minotaur implements Plugin<Project> {
 		tasks.register("modrinth", TaskModrinthUpload.class, task -> {
 			task.setGroup("publishing");
 			task.setDescription("Upload project to Modrinth");
-			task.dependsOn(tasks.named("assemble"));
-			task.mustRunAfter(tasks.named("build"));
 			task.notCompatibleWithConfigurationCache("Fundamentally incompatible with configuration cache");
 		});
 		project.getLogger().debug("Registered the `modrinth` task.");
@@ -48,6 +46,8 @@ public class Minotaur implements Plugin<Project> {
 			}
 
 			evaluatedProject.getTasks().named("modrinth", TaskModrinthUpload.class).configure(task -> {
+				task.dependsOn(evaluatedProject.getTasks().named("assemble"));
+				task.mustRunAfter(evaluatedProject.getTasks().named("build"));
 				task.getWiredInputFiles().from(ext.getFile());
 				task.getInputs().property("changelog", ext.getChangelog()).optional(true);
 


### PR DESCRIPTION
## Summary
Fixes #81. The `dependsOn("assemble")` and `mustRunAfter("build")` calls in `Minotaur.java` were applied unconditionally at plugin apply time, so setting `autoAddDependsOn = false` in the extension had no effect on those wirings (only the file-wiring inside the `afterEvaluate` block was being skipped).

This PR moves both calls into the existing `afterEvaluate` block, which is already guarded by `ext.getAutoAddDependsOn().get()`. Default behavior is preserved (the flag defaults to true).

## Test plan
- [x] `./gradlew compileJava` passes (no new warnings vs. baseline)
- [ ] With `autoAddDependsOn = false`, running `:modrinth` no longer triggers `:assemble`
- [ ] With default settings, `:modrinth` still depends on `:assemble` and runs after `:build`

Closes #81.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>