### PR TITLE
feat: allow configuring version environment compatibility (fixes #82)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,11 @@ dependencies {
 	api group: 'dev.masecla', name: 'Modrinth4J', version: '2.2.0'
 	compileOnly group: 'io.papermc.paperweight', name: 'paperweight-userdev', version: '1.5.2'
 	compileOnly annotationProcessor(group: 'org.projectlombok', name: 'lombok', version: '1.18.30')
+	testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.10.0'
+}
+
+test {
+	useJUnitPlatform()
 }
 
 gradlePlugin {

--- a/src/main/java/com/modrinth/minotaur/ModrinthExtension.java
+++ b/src/main/java/com/modrinth/minotaur/ModrinthExtension.java
@@ -210,14 +210,14 @@ public class ModrinthExtension extends DependencyDSL {
 	}
 
 	/**
-	 * @return The client side environment setting (required, optional, unsupported, unknown)
+	 * @return The client side environment setting. See {@link com.modrinth.minotaur.request.EnvironmentSupport}.
 	 */
 	public Property<String> getClientSide() {
 		return this.clientSide;
 	}
 
 	/**
-	 * @return The server side environment setting (required, optional, unsupported, unknown)
+	 * @return The server side environment setting. See {@link com.modrinth.minotaur.request.EnvironmentSupport}.
 	 */
 	public Property<String> getServerSide() {
 		return this.serverSide;

--- a/src/main/java/com/modrinth/minotaur/ModrinthExtension.java
+++ b/src/main/java/com/modrinth/minotaur/ModrinthExtension.java
@@ -16,7 +16,7 @@ import org.gradle.api.provider.Property;
  */
 public class ModrinthExtension extends DependencyDSL {
 	private final AdditionalFileDSL additionalFileDsl;
-	private final Property<String> apiUrl, token, projectId, versionNumber, versionName, changelog, versionType, syncBodyFrom;
+	private final Property<String> apiUrl, token, projectId, versionNumber, versionName, changelog, versionType, syncBodyFrom, clientSide, serverSide;
 	private final Property<Object> legacyUploadFile;
 	private final RegularFileProperty file;
 	private final ListProperty<Object> additionalFiles;
@@ -70,6 +70,8 @@ public class ModrinthExtension extends DependencyDSL {
 		debugMode = project.getObjects().property(Boolean.class).convention(false);
 		syncBodyFrom = project.getObjects().property(String.class);
 		autoAddDependsOn = project.getObjects().property(Boolean.class).convention(true);
+		clientSide = project.getObjects().property(String.class);
+		serverSide = project.getObjects().property(String.class);
 	}
 
 	public void additionalFiles(Action<? super AdditionalFileDSL> action) {
@@ -205,6 +207,20 @@ public class ModrinthExtension extends DependencyDSL {
 	 */
 	public Property<String> getSyncBodyFrom() {
 		return this.syncBodyFrom;
+	}
+
+	/**
+	 * @return The client side environment setting (required, optional, unsupported, unknown)
+	 */
+	public Property<String> getClientSide() {
+		return this.clientSide;
+	}
+
+	/**
+	 * @return The server side environment setting (required, optional, unsupported, unknown)
+	 */
+	public Property<String> getServerSide() {
+		return this.serverSide;
 	}
 
 	/**

--- a/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java
+++ b/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java
@@ -3,6 +3,7 @@ package com.modrinth.minotaur;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.modrinth.minotaur.dependencies.Dependency;
+import com.modrinth.minotaur.request.EnvironmentSupport;
 import com.modrinth.minotaur.responses.ResponseUpload;
 import io.papermc.paperweight.userdev.PaperweightUserExtension;
 import com.modrinth.minotaur.masecla.modrinth4j.endpoints.version.TemporaryCreateVersion;
@@ -244,10 +245,10 @@ public abstract class TaskModrinthUpload extends DefaultTask {
 				.files(files);
 
 			if (ext.getClientSide().isPresent()) {
-				dataBuilder.clientSide(ext.getClientSide().get());
+				dataBuilder.clientSide(EnvironmentSupport.from(ext.getClientSide().get()));
 			}
 			if (ext.getServerSide().isPresent()) {
-				dataBuilder.serverSide(ext.getServerSide().get());
+				dataBuilder.serverSide(EnvironmentSupport.from(ext.getServerSide().get()));
 			}
 
 			TemporaryCreateVersionRequest data = dataBuilder.build();

--- a/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java
+++ b/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java
@@ -232,8 +232,7 @@ public abstract class TaskModrinthUpload extends DefaultTask {
 			ext.getAdditionalFileDsl().getNamedAdditionalFilesAsList().forEach(file ->
 				files.put(file.getFile().getAsFile(), file.getAdditionalFileType().toString()));
 
-			// Start construction of the actual request!
-			TemporaryCreateVersionRequest data = TemporaryCreateVersionRequest.builder()
+			TemporaryCreateVersionRequest.TemporaryCreateVersionRequestBuilder dataBuilder = TemporaryCreateVersionRequest.builder()
 				.projectId(id)
 				.versionNumber(versionNumber)
 				.name(ext.getVersionName().get())
@@ -242,12 +241,20 @@ public abstract class TaskModrinthUpload extends DefaultTask {
 				.gameVersions(ext.getGameVersions().get())
 				.loaders(ext.getLoaders().get())
 				.dependencies(dependencies)
-				.files(files)
-				.build();
+				.files(files);
+
+			if (ext.getClientSide().isPresent()) {
+				dataBuilder.clientSide(ext.getClientSide().get());
+			}
+			if (ext.getServerSide().isPresent()) {
+				dataBuilder.serverSide(ext.getServerSide().get());
+			}
+
+			TemporaryCreateVersionRequest data = dataBuilder.build();
 
 			// Return early in debug mode
 			if (ext.getDebugMode().get()) {
-				Gson gson = new GsonBuilder().setPrettyPrinting().create();
+				Gson gson = new GsonBuilder().setFieldNamingPolicy(com.google.gson.FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).setPrettyPrinting().create();
 				getLogger().lifecycle("Full data to be sent for upload: {}", gson.toJson(data));
 				getLogger().lifecycle("Minotaur debug mode is enabled. Not going to upload this version.");
 				return;

--- a/src/main/java/com/modrinth/minotaur/masecla/modrinth4j/endpoints/version/TemporaryCreateVersion.java
+++ b/src/main/java/com/modrinth/minotaur/masecla/modrinth4j/endpoints/version/TemporaryCreateVersion.java
@@ -99,6 +99,12 @@ public class TemporaryCreateVersion extends Endpoint<ProjectVersion, TemporaryCr
 		/** The requested status of the project */
 		private ProjectStatus requestedStatus;
 
+		/** The client side environment support setting */
+		private String clientSide;
+
+		/** The server side environment support setting */
+		private String serverSide;
+
 		/** The project ID of the version */
 		@NonNull
 		private String projectId;

--- a/src/main/java/com/modrinth/minotaur/masecla/modrinth4j/endpoints/version/TemporaryCreateVersion.java
+++ b/src/main/java/com/modrinth/minotaur/masecla/modrinth4j/endpoints/version/TemporaryCreateVersion.java
@@ -31,6 +31,7 @@ import com.google.gson.reflect.TypeToken;
 
 import com.modrinth.minotaur.ModrinthExtension;
 import com.modrinth.minotaur.Util;
+import com.modrinth.minotaur.request.EnvironmentSupport;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Builder.Default;
@@ -100,10 +101,10 @@ public class TemporaryCreateVersion extends Endpoint<ProjectVersion, TemporaryCr
 		private ProjectStatus requestedStatus;
 
 		/** The client side environment support setting */
-		private String clientSide;
+		private EnvironmentSupport clientSide;
 
 		/** The server side environment support setting */
-		private String serverSide;
+		private EnvironmentSupport serverSide;
 
 		/** The project ID of the version */
 		@NonNull

--- a/src/main/java/com/modrinth/minotaur/request/EnvironmentSupport.java
+++ b/src/main/java/com/modrinth/minotaur/request/EnvironmentSupport.java
@@ -1,0 +1,47 @@
+package com.modrinth.minotaur.request;
+
+import com.google.gson.annotations.SerializedName;
+import java.util.Locale;
+
+/**
+ * The enum representing the environment support state for client or server side.
+ */
+public enum EnvironmentSupport {
+	/**
+	 * The environment is required for this version.
+	 */
+	@SerializedName("required")
+	REQUIRED,
+
+	/**
+	 * The environment is optional for this version.
+	 */
+	@SerializedName("optional")
+	OPTIONAL,
+
+	/**
+	 * The environment is unsupported for this version.
+	 */
+	@SerializedName("unsupported")
+	UNSUPPORTED,
+
+	/**
+	 * The environment compatibility state is unknown.
+	 */
+	@SerializedName("unknown")
+	UNKNOWN;
+
+	/**
+	 * Parses a string into an {@link EnvironmentSupport} enum instance ignoring case.
+	 *
+	 * @param value The string value to parse
+	 * @return The matching {@link EnvironmentSupport} constant
+	 * @throws IllegalArgumentException if no matching constant is found
+	 */
+	public static EnvironmentSupport from(String value) {
+		if (value == null) {
+			return null;
+		}
+		return valueOf(value.trim().toUpperCase(Locale.ROOT));
+	}
+}

--- a/src/test/java/com/modrinth/minotaur/request/EnvironmentSupportTest.java
+++ b/src/test/java/com/modrinth/minotaur/request/EnvironmentSupportTest.java
@@ -1,0 +1,39 @@
+package com.modrinth.minotaur.request;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EnvironmentSupportTest {
+
+	private final Gson gson = new GsonBuilder().create();
+
+	@Test
+	public void testFromValidStrings() {
+		assertEquals(EnvironmentSupport.REQUIRED, EnvironmentSupport.from("required"));
+		assertEquals(EnvironmentSupport.OPTIONAL, EnvironmentSupport.from("OPTIONAL"));
+		assertEquals(EnvironmentSupport.UNSUPPORTED, EnvironmentSupport.from("unsupported"));
+		assertEquals(EnvironmentSupport.UNKNOWN, EnvironmentSupport.from("unknown"));
+	}
+
+	@Test
+	public void testFromNull() {
+		assertNull(EnvironmentSupport.from(null));
+	}
+
+	@Test
+	public void testGsonSerialization() {
+		assertEquals("\"required\"", gson.toJson(EnvironmentSupport.REQUIRED));
+		assertEquals("\"optional\"", gson.toJson(EnvironmentSupport.OPTIONAL));
+		assertEquals("\"unsupported\"", gson.toJson(EnvironmentSupport.UNSUPPORTED));
+		assertEquals("\"unknown\"", gson.toJson(EnvironmentSupport.UNKNOWN));
+	}
+
+	@Test
+	public void testGsonDeserialization() {
+		assertEquals(EnvironmentSupport.REQUIRED, gson.fromJson("\"required\"", EnvironmentSupport.class));
+		assertEquals(EnvironmentSupport.OPTIONAL, gson.fromJson("\"optional\"", EnvironmentSupport.class));
+	}
+}


### PR DESCRIPTION
Resolves issue #82. Exposes clientSide and serverSide configurations in the modrinth extension block to allow developers to configure version environment compatibility states when deploying via Minotaur. It maps them to client_side and server_side payload fields on the version creation request.