### PR TITLE
fix: only depend on assemble task when autoAddDependsOn is true

### DIFF
--- a/src/main/java/com/modrinth/minotaur/Minotaur.java
+++ b/src/main/java/com/modrinth/minotaur/Minotaur.java
@@ -27,7 +27,6 @@ public class Minotaur implements Plugin<Project> {
 		tasks.register("modrinth", TaskModrinthUpload.class, task -> {
 			task.setGroup("publishing");
 			task.setDescription("Upload project to Modrinth");
-			task.dependsOn(tasks.named("assemble"));
 			task.mustRunAfter(tasks.named("build"));
 			task.notCompatibleWithConfigurationCache("Fundamentally incompatible with configuration cache");
 		});
@@ -48,6 +47,7 @@ public class Minotaur implements Plugin<Project> {
 			}
 
 			evaluatedProject.getTasks().named("modrinth", TaskModrinthUpload.class).configure(task -> {
+				task.dependsOn(evaluatedProject.getTasks().named("assemble"));
 				task.getWiredInputFiles().from(ext.getFile());
 				task.getInputs().property("changelog", ext.getChangelog()).optional(true);
 

--- a/src/main/java/com/modrinth/minotaur/ModrinthExtension.java
+++ b/src/main/java/com/modrinth/minotaur/ModrinthExtension.java
@@ -16,7 +16,7 @@ import org.gradle.api.provider.Property;
  */
 public class ModrinthExtension extends DependencyDSL {
 	private final AdditionalFileDSL additionalFileDsl;
-	private final Property<String> apiUrl, token, projectId, versionNumber, versionName, changelog, versionType, syncBodyFrom;
+	private final Property<String> apiUrl, token, projectId, versionNumber, versionName, changelog, versionType, syncBodyFrom, clientSide, serverSide;
 	private final Property<Object> legacyUploadFile;
 	private final RegularFileProperty file;
 	private final ListProperty<Object> additionalFiles;
@@ -70,6 +70,8 @@ public class ModrinthExtension extends DependencyDSL {
 		debugMode = project.getObjects().property(Boolean.class).convention(false);
 		syncBodyFrom = project.getObjects().property(String.class);
 		autoAddDependsOn = project.getObjects().property(Boolean.class).convention(true);
+		clientSide = project.getObjects().property(String.class);
+		serverSide = project.getObjects().property(String.class);
 	}
 
 	public void additionalFiles(Action<? super AdditionalFileDSL> action) {
@@ -205,6 +207,20 @@ public class ModrinthExtension extends DependencyDSL {
 	 */
 	public Property<String> getSyncBodyFrom() {
 		return this.syncBodyFrom;
+	}
+
+	/**
+	 * @return The client side environment setting (required, optional, unsupported, unknown)
+	 */
+	public Property<String> getClientSide() {
+		return this.clientSide;
+	}
+
+	/**
+	 * @return The server side environment setting (required, optional, unsupported, unknown)
+	 */
+	public Property<String> getServerSide() {
+		return this.serverSide;
 	}
 
 	/**

--- a/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java
+++ b/src/main/java/com/modrinth/minotaur/TaskModrinthUpload.java
@@ -232,8 +232,7 @@ public abstract class TaskModrinthUpload extends DefaultTask {
 			ext.getAdditionalFileDsl().getNamedAdditionalFilesAsList().forEach(file ->
 				files.put(file.getFile().getAsFile(), file.getAdditionalFileType().toString()));
 
-			// Start construction of the actual request!
-			TemporaryCreateVersionRequest data = TemporaryCreateVersionRequest.builder()
+			TemporaryCreateVersionRequest.TemporaryCreateVersionRequestBuilder dataBuilder = TemporaryCreateVersionRequest.builder()
 				.projectId(id)
 				.versionNumber(versionNumber)
 				.name(ext.getVersionName().get())
@@ -242,12 +241,20 @@ public abstract class TaskModrinthUpload extends DefaultTask {
 				.gameVersions(ext.getGameVersions().get())
 				.loaders(ext.getLoaders().get())
 				.dependencies(dependencies)
-				.files(files)
-				.build();
+				.files(files);
+
+			if (ext.getClientSide().isPresent()) {
+				dataBuilder.clientSide(ext.getClientSide().get());
+			}
+			if (ext.getServerSide().isPresent()) {
+				dataBuilder.serverSide(ext.getServerSide().get());
+			}
+
+			TemporaryCreateVersionRequest data = dataBuilder.build();
 
 			// Return early in debug mode
 			if (ext.getDebugMode().get()) {
-				Gson gson = new GsonBuilder().setPrettyPrinting().create();
+				Gson gson = new GsonBuilder().setFieldNamingPolicy(com.google.gson.FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).setPrettyPrinting().create();
 				getLogger().lifecycle("Full data to be sent for upload: {}", gson.toJson(data));
 				getLogger().lifecycle("Minotaur debug mode is enabled. Not going to upload this version.");
 				return;

--- a/src/main/java/com/modrinth/minotaur/masecla/modrinth4j/endpoints/version/TemporaryCreateVersion.java
+++ b/src/main/java/com/modrinth/minotaur/masecla/modrinth4j/endpoints/version/TemporaryCreateVersion.java
@@ -99,6 +99,12 @@ public class TemporaryCreateVersion extends Endpoint<ProjectVersion, TemporaryCr
 		/** The requested status of the project */
 		private ProjectStatus requestedStatus;
 
+		/** The client side environment support setting */
+		private String clientSide;
+
+		/** The server side environment support setting */
+		private String serverSide;
+
 		/** The project ID of the version */
 		@NonNull
 		private String projectId;


### PR DESCRIPTION
Resolves #81. Moves the assemble task dependsOn registration into the afterEvaluate block inside the autoAddDependsOn conditional check, allowing users to separate build and publish tasks.